### PR TITLE
Fix erroneous bit-or reduction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ group id.
  - Support for the `guild-scheduled-events` intent
 
 ### Fixed
+ - Arity exception in permissions namespace
  - Reflection warning from the util ns
  - Incorrect gateway version was requested
 

--- a/src/discljord/permissions.clj
+++ b/src/discljord/permissions.clj
@@ -79,11 +79,12 @@
 (defn- override
   "Integrates the overrides into the permissions int."
   [perms-int overrides]
-  (let [allow (or (when (seq overrides)
-                    (reduce (comp bit-or util/parse-if-str) 0 (map :allow overrides)))
+  (let [combine-overrides #(bit-or %1 (util/parse-if-str %2))
+        allow (or (when (seq overrides)
+                    (reduce combine-overrides 0 (map :allow overrides)))
                   0)
         deny (or (when (seq overrides)
-                   (reduce #(bit-or %1 (util/parse-if-str %2)) 0 (map :deny overrides)))
+                   (reduce combine-overrides 0 (map :deny overrides)))
                  0)]
     (bit-or
      (bit-and

--- a/src/discljord/permissions.clj
+++ b/src/discljord/permissions.clj
@@ -83,7 +83,7 @@
                     (reduce (comp bit-or util/parse-if-str) 0 (map :allow overrides)))
                   0)
         deny (or (when (seq overrides)
-                   (reduce (comp bit-or util/parse-if-str) 0 (map :deny overrides)))
+                   (reduce #(bit-or %1 (util/parse-if-str %2)) 0 (map :deny overrides)))
                  0)]
     (bit-or
      (bit-and

--- a/src/discljord/permissions.clj
+++ b/src/discljord/permissions.clj
@@ -55,7 +55,7 @@
   "Returns a set of all permissions included in a given permission integer."
   [perms-int]
   (->> (vals permissions-bit)
-       (filter (comp (complement zero?) (partial bit-and (util/parse-if-str perms-int))))
+       (remove (comp zero? (partial bit-and (util/parse-if-str perms-int))))
        (map permissions-key)
        (set)))
 


### PR DESCRIPTION
In `discljord.permission`, `(comp bit-or util/parse-if-str)` was used as a reduction function in a few places. This would throw an arity exception because `util/parse-if-str` would try to consume the two parameters, while only supporting 1 parameter.\
These bugs are fixed in this PR.