### PR TITLE
Fix typo in start-thread-without-message impl

### DIFF
--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -315,7 +315,7 @@
   (str "/channels/" channel-id "/threads")
   {:body (json/write-str {:name name
                           :auto_archive_duration auto-archive-duration
-                          :tyoe type})}
+                          :type type})}
   (json-body body))
 
 (defdispatch :join-thread


### PR DESCRIPTION
Serialise `:type` key to JSON rather than typo `:tyoe`. Should allow `start-thread-without-message` to work.