### PR TITLE
Fix typo in `modify-guild-role!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Fixed
+- Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working
 
 ## [1.3.1] - 2022-01-22

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -479,7 +479,7 @@
   [roles]
   [])
 
-(defendpoint modifiy-guild-role! ::ds/guild-id
+(defendpoint modify-guild-role! ::ds/guild-id
   "Modifies the given role. Returns a promise containing the modified role object."
   [role-id]
   [name permissions color hoist mentionable])


### PR DESCRIPTION
This PR fixes a typo in the endpoint definition of `modify-guild-role!`, which was erroneously called `modifiy-guild-role!` before. This rendered the function unusable because the typo was not mirrored in the actual implementation of the endpoint. I.e., up to now, calling this function simply resulted in an exception.