### PR TITLE
Fix pin endpoint error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Fixed
+- Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`
 - Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working
 

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -226,12 +226,12 @@
   []
   [])
 
-(defendpoint add-channel-pinned-message! ::ds/channel-id
+(defendpoint ^:deprecated add-channel-pinned-message! ::ds/channel-id
   "Pins the given message to the channel. Returns a promise containing a boolean of if it succeeded."
   [message-id]
   [])
 
-(defendpoint delete-pinned-channel-message! ::ds/channel-id
+(defendpoint ^:deprecated delete-pinned-channel-message! ::ds/channel-id
   "Removes a message from the pinned list in the channel. Returns a promise containing a boolean of if it succeeded."
   [message-id]
   [])

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -236,6 +236,16 @@
   [message-id]
   [])
 
+(defendpoint pin-message! ::ds/channel-id
+  "Pins the given message to the channel. Returns a promise containing a boolean of if it succeeded."
+  [message-id]
+  [])
+
+(defendpoint unpin-message! ::ds/channel-id
+  "Removes a message from the pinned list in the channel. Returns a promise containing a boolean of if it succeeded."
+  [message-id]
+  [])
+
 (defendpoint group-dm-add-recipient! ::ds/channel-id
   "NOT INTENDED FOR BOT USE. Adds a new recipient to a group DM channel. Requires an access token."
   [user-id]

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -291,6 +291,12 @@
   {}
   (= status 204))
 
+(defmethod dispatch-http :add-channel-pinned-message
+  [token endpoint & args] (apply dispatch-http token (assoc endpoint ::ms/action :pin-message) args))
+
+(defmethod dispatch-http :delete-pinned-channel-message
+  [token endpoint & args] (apply dispatch-http token (assoc endpoint ::ms/action :unpin-message) args))
+
 (defdispatch :group-dm-add-recipient
   [channel-id user-id] [] opts :put _ _
   (str "/channels/" channel-id "/recipients/" user-id)

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -279,13 +279,13 @@
   {}
   (json-body body))
 
-(defdispatch :add-pinned-channel-message
+(defdispatch :pin-message
   [channel-id message-id] [] _ :put status _
   (str "/channels/" channel-id "/pins/" message-id)
   {}
   (= status 204))
 
-(defdispatch :delete-pinned-channel-message
+(defdispatch :unpin-message
   [channel-id message-id] [] _ :delete status _
   (str "/channels/" channel-id "/pins/" message-id)
   {}


### PR DESCRIPTION
The pin endpoint (`add-channel-pinned-message!`) currently does not work because the name was (presumably) mistyped, it should have been `add-pinned-channel-message!` instead (matching the dispatch implementation). 
To fix this issue, I have added 2 new endpoints `pin-message!` and `unpin-message!` (matching the names in the [Discord docs](https://discord.com/developers/docs/resources/channel#pin-message)) which are the replacements for the old functions. Those old endpoint functions still exist and now delegate to the new ones, but have been marked as `^:deprecated`.