### PR TITLE
Fixes for issue #108 & failing unit test fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Discljord follows semantic versioning.
 - Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`
 - Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working
-- Fix issue #108 - dependencies have slowly fallen out of date
+- Fix [issue #108 - dependencies have slowly fallen out of date](https://github.com/discljord/discljord/issues/108)
 
 ## [1.3.1] - 2022-01-22
 IMPORTANT, this is the first release on the new com.github.discljord group id.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Discljord follows semantic versioning.
 - Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`
 - Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working
+- Fix issue #108 - dependencies have slowly fallen out of date
 
 ## [1.3.1] - 2022-01-22
 IMPORTANT, this is the first release on the new com.github.discljord group id.

--- a/deps.edn
+++ b/deps.edn
@@ -3,32 +3,30 @@
         org.clojure/core.async {:mvn/version "1.5.648"}
         org.clojure/data.json {:mvn/version "2.4.0"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
-        http-kit/http-kit {:mvn/version "2.5.3"}
+        http-kit/http-kit {:mvn/version "2.6.0-RC1"}
         stylefruits/gniazdo {:mvn/version "1.2.1"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]
-        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.2.3"}}
+        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.2.11"}}
         :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}
   :test {:extra-paths ["test"]
          :extra-deps {http-kit.fake/http-kit.fake {:mvn/version "0.2.2"}
-                      org.clojure/test.check {:mvn/version "1.1.0"}}}
-  :runner
-  {:extra-deps {com.cognitect/test-runner
-                {:git/url "https://github.com/cognitect-labs/test-runner"
-                 :sha "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
-   :main-opts ["-m" "cognitect.test-runner"
-               "-d" "test"]}
+                      org.clojure/test.check {:mvn/version "1.1.1"}}}
+  :runner {:extra-paths ["test"]
+           :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :main-opts ["-m" "cognitect.test-runner"]
+           :exec-fn cognitect.test-runner.api/test}
 
-  :jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.0.216"}}
+  :jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
         :exec-fn hf.depstar/jar
         :exec-args {:jar "discljord.jar" :sync-pom true
                     :group-id "com.github.discljord" :artifact-id "discljord"
                     :version "1.3.1"}}
-  :install {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
+  :install {:replace-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
             :exec-fn deps-deploy.deps-deploy/deploy
             :exec-args {:installer :local :artifact "discljord.jar"}}
-  :deploy {:replace-deps {slipset/deps-deploy {:mvn/version "0.1.5"}}
+  :deploy {:replace-deps {slipset/deps-deploy {:mvn/version "RELEASE"}}
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :remote :artifact "discljord.jar"
                        :sign-releases? true}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
 
  :aliases
  {:dev {:extra-paths ["dev"]
-        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.2.11"}}
+        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.4.1"}}
         :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}
   :test {:extra-paths ["test"]
          :extra-deps {http-kit.fake/http-kit.fake {:mvn/version "0.2.2"}

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         org.clojure/core.async {:mvn/version "1.5.648"}
         org.clojure/data.json {:mvn/version "2.4.0"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
-        http-kit/http-kit {:mvn/version "2.6.0-RC1"}
+        http-kit/http-kit {:mvn/version "2.5.3"}
         stylefruits/gniazdo {:mvn/version "1.2.1"}}
 
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
         org.clojure/core.async {:mvn/version "1.5.648"}
         org.clojure/data.json {:mvn/version "2.4.0"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
-        http-kit/http-kit {:mvn/version "2.5.3"}
+        http-kit/http-kit {:mvn/version "2.6.0"}
         stylefruits/gniazdo {:mvn/version "1.2.1"}}
 
  :aliases

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,10 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        org.clojure/core.async {:mvn/version "1.3.618"}
-        org.clojure/data.json {:mvn/version "2.3.1"}
-        org.clojure/tools.logging {:mvn/version "1.1.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        org.clojure/core.async {:mvn/version "1.5.648"}
+        org.clojure/data.json {:mvn/version "2.4.0"}
+        org.clojure/tools.logging {:mvn/version "1.2.4"}
         http-kit/http-kit {:mvn/version "2.5.3"}
-        stylefruits/gniazdo {:mvn/version "1.2.0"}}
+        stylefruits/gniazdo {:mvn/version "1.2.1"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]

--- a/project.clj
+++ b/project.clj
@@ -7,13 +7,13 @@
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/data.json "2.4.0"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [http-kit/http-kit "2.5.3"]
+                 [http-kit/http-kit "2.6.0"]
                  [stylefruits/gniazdo "1.2.1"]]
   :target-path "target/%s"
   :jar-name "discljord-%s.jar"
   :deploy-branches ["master" "release" "hotfix"]
   :profiles {:dev {:dependencies [[http-kit.fake/http-kit.fake "0.2.2"]
-                                  [ch.qos.logback/logback-classic "1.2.11"]]
+                                  [ch.qos.logback/logback-classic "1.4.1"]]
                    :plugins [[lein-codox "0.10.8"]]
                    :exclusions [http-kit]
                    :jvm-opts ["--add-opens" "java.base/java.lang=ALL-UNNAMED" "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}})

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/data.json "2.4.0"]
                  [org.clojure/tools.logging "1.2.4"]
-                 [http-kit/http-kit "2.6.0-RC1"]
+                 [http-kit/http-kit "2.5.3"]
                  [stylefruits/gniazdo "1.2.1"]]
   :target-path "target/%s"
   :jar-name "discljord-%s.jar"

--- a/project.clj
+++ b/project.clj
@@ -3,17 +3,17 @@
   :url "https://github.com/IGJoshua/discljord"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.clojure/core.async "1.3.618"]
-                 [org.clojure/data.json "2.3.1"]
-                 [org.clojure/tools.logging "1.1.0"]
-                 [http-kit/http-kit "2.5.3"]
-                 [stylefruits/gniazdo "1.2.0"]]
+  :dependencies [[org.clojure/clojure "1.11.1"]
+                 [org.clojure/core.async "1.5.648"]
+                 [org.clojure/data.json "2.4.0"]
+                 [org.clojure/tools.logging "1.2.4"]
+                 [http-kit/http-kit "2.6.0-RC1"]
+                 [stylefruits/gniazdo "1.2.1"]]
   :target-path "target/%s"
   :jar-name "discljord-%s.jar"
   :deploy-branches ["master" "release" "hotfix"]
   :profiles {:dev {:dependencies [[http-kit.fake/http-kit.fake "0.2.2"]
-                                  [ch.qos.logback/logback-classic "1.2.3"]]
-                   :plugins [[lein-codox "0.10.7"]]
+                                  [ch.qos.logback/logback-classic "1.2.11"]]
+                   :plugins [[lein-codox "0.10.8"]]
                    :exclusions [http-kit]
                    :jvm-opts ["--add-opens" "java.base/java.lang=ALL-UNNAMED" "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}})

--- a/test/discljord/connections_test.clj
+++ b/test/discljord/connections_test.clj
@@ -77,7 +77,7 @@
                                                 "t" "READY"
                                                 "d" {"session_id" "session"}})))
                         nil)))]
-      (fake/with-fake-http ["https://discord.com/api/gateway/bot?v=8&encoding=json"
+      (fake/with-fake-http ["https://discord.com/api/gateway/bot?v=9&encoding=json"
                             (fn [orig-fn opts callback]
                               (if (= (get (:headers opts) "Authorization")
                                      "Bot VALID_TOKEN")

--- a/test/discljord/connections_test.clj
+++ b/test/discljord/connections_test.clj
@@ -3,6 +3,7 @@
    [clojure.core.async :as a]
    [clojure.data.json :as json]
    [clojure.test :as t]
+   [discljord.http :as ht]
    [discljord.connections :as c]
    [discljord.connections.specs :as cs]
    [discljord.specs :as ds]
@@ -77,7 +78,7 @@
                                                 "t" "READY"
                                                 "d" {"session_id" "session"}})))
                         nil)))]
-      (fake/with-fake-http ["https://discord.com/api/gateway/bot?v=9&encoding=json"
+      (fake/with-fake-http [(str "https://discord.com/api/gateway/bot?v=" ht/gateway-version "&encoding=json")
                             (fn [orig-fn opts callback]
                               (if (= (get (:headers opts) "Authorization")
                                      "Bot VALID_TOKEN")


### PR DESCRIPTION
* Fix for issue #108
* Fix for failing unit test fixture (URL had fallen out of sync with code)

Output from `clj -A:test -M:runner`:
```
$ clj -A:test -M:runner

Running tests in #{"test"}

Testing discljord.connections-test
May 12, 2022 5:43:14 PM clojure.tools.logging$eval10805$fn__10808 invoke
INFO: Connecting shard 0
2022-05-12 17:43:14.392:INFO::async-dispatch-3: Logging initialized @5522ms to org.eclipse.jetty.util.log.StdErrLog
May 12, 2022 5:43:15 PM clojure.tools.logging$eval10805$fn__10808 invoke
INFO: Full disconnect triggered from input

Ran 2 tests containing 11 assertions.
0 failures, 0 errors.
```