### PR TITLE
Add error response logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file. This change
 Discljord follows semantic versioning.
 
 ## [Unreleased]
+### Added
+- Every endpoint function can now log error responses at log level ERROR. This is enabled by default, but can be disabled for individual invocations using the new keyword arg `:log-error?` that is available for every endpoint function.
+
 ### Fixed
+- Keyword args in endpoint functions were declared incorrectly (`:keys [:a :b :c]` instead of `:keys [a b c]`). This had no semantic effect but has been corrected nonetheless.
 - Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`
 - Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -62,7 +62,7 @@
                     (symbol (name major-var-type)))
         sym-name (name endpoint-name)
         action (keyword (subs sym-name 0 (dec (count sym-name))))
-        opts (conj opts 'user-agent 'audit-reason)
+        opts (conj opts 'user-agent 'audit-reason 'log-error?)
         prepend-major-var? (and major-var (not (contains? (set params) major-var)))
         spec-args (cond->> (map (juxt (comp keyword name) spec-for) params)
                            prepend-major-var? (cons [(keyword major-var) major-var-type])
@@ -73,10 +73,8 @@
     `(do
        (defn ~endpoint-name
          ~doc-str
-         [~'conn ~@unqualified-params ~'& {:keys ~unqualified-opts :as ~'opts}]
-         (let [user-agent# (:user-agent ~'opts)
-               audit-reason# (:audit-reason ~'opts)
-               p# (util/derefable-promise-chan)
+         [~'conn ~@unqualified-params ~'& {:keys ~unqualified-opts :as ~'opts :or {~'log-error? true}}]
+         (let [p# (util/derefable-promise-chan)
                action# {::ms/action ~action}]
            (a/put! ~'conn (into [(cond-> action#
                                          ~major-var-type (assoc ::ms/major-variable
@@ -84,10 +82,9 @@
                                                             ::ms/major-variable-value ~major-var}))
                                  p#
                                  ~@(remove #{major-var} unqualified-params)
-                                 :user-agent user-agent#
-                                 :audit-reason audit-reason#]
+                                 :log-error? ~'log-error?]
                                 cat
-                                (dissoc ~'opts :user-agent)))
+                                (dissoc ~'opts :log-error?)))
            p#))
        (s/fdef ~endpoint-name
          :args (s/cat :conn ::ds/channel

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -69,7 +69,7 @@
                            true vec)
         spec-keys (vec (map spec-for opts))
         unqualified-params (cond->> (map (comp symbol name) params) prepend-major-var? (cons major-var))
-        unqualified-opts (mapv (comp keyword name) opts)]
+        unqualified-opts (mapv (comp symbol name) opts)]
     `(do
        (defn ~endpoint-name
          ~doc-str

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -41,6 +41,10 @@
         ") "
         user-agent)})
 
+(defn log-error-response [endpoint status response-body]
+  (when (not= (mod status 100) 2)
+    (log/error "Encountered error response" status "on" endpoint ":\n" response-body)))
+
 (defmacro defdispatch
   "Defines a dispatch method for the the endpoint with `endpoint-name`.
 
@@ -82,6 +86,7 @@
              ~'_ (log/trace "Response:" response#)
              ~status-sym (:status response#)
              ~body-sym (:body response#)]
+         (log-error-response ~endpoint-name ~status-sym ~body-sym)
          (when-not (= ~status-sym 429)
            (let [prom-val# ~promise-val]
              (if (some? prom-val#)

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -41,8 +41,8 @@
         ") "
         user-agent)})
 
-(defn log-error-response [endpoint status response-body]
-  (when (not= (mod status 100) 2)
+(defn maybe-log-error [log-error? endpoint status response-body]
+  (when (and log-error? (not= (mod status 100) 2))
     (log/error "Encountered error response" status "on" endpoint ":\n" response-body)))
 
 (defmacro defdispatch
@@ -66,7 +66,7 @@
   (let [token-sym (gensym "token")
         user-agent-sym (gensym "user-agent")]
     `(defmethod dispatch-http ~endpoint-name
-       [~token-sym endpoint# [prom# ~@params & {~user-agent-sym :user-agent audit-reason# :audit-reason
+       [~token-sym endpoint# [prom# ~@params & {~user-agent-sym :user-agent audit-reason# :audit-reason log-error# :log-error?
                                                 :keys [~@opts] :as opts#}]]
        (let [~opts-sym (dissoc opts# :user-agent)
              ~major-var (-> endpoint#
@@ -86,7 +86,7 @@
              ~'_ (log/trace "Response:" response#)
              ~status-sym (:status response#)
              ~body-sym (:body response#)]
-         (log-error-response ~endpoint-name ~status-sym ~body-sym)
+         (maybe-log-error log-error# ~endpoint-name ~status-sym ~body-sym)
          (when-not (= ~status-sym 429)
            (let [prom-val# ~promise-val]
              (if (some? prom-val#)
@@ -154,7 +154,7 @@
   {}
   (json-body body))
 
-(defn- send-message! [token url prom multipart always-expect-content? {:keys [wait ^File file user-agent allowed-mentions stream message-reference] :as opts}]
+(defn- send-message! [token url prom multipart always-expect-content? {:keys [wait ^File file user-agent allowed-mentions stream message-reference log-error?] :as opts}]
   (let [payload (-> opts
                     (dissoc :user-agent :file :stream)
                     conform-to-json
@@ -173,6 +173,7 @@
                (cond->> (json-body raw-body)
                  (not= 2 (quot status 100)) (ex-info "Attempted to send an invalid message payload"))
                (= status 204))]
+    (maybe-log-error log-error? :send-message status raw-body)
     (when-not (= status 429)
       (if (some? body)
         (a/>!! prom body)
@@ -1032,7 +1033,7 @@
   (json-body body))
 
 (defmethod dispatch-http :create-guild-sticker
-  [token endpoint [prom & {:keys [name description tags ^File file user-agent audit-reason]}]]
+  [token endpoint [prom & {:keys [name description tags ^File file user-agent audit-reason log-error?]}]]
   (let [guild-id (-> endpoint
                      ::ms/major-variable
                      ::ms/major-variable-value)
@@ -1053,6 +1054,7 @@
         status (:status response)
         body (cond->> (json-body (:body response))
                (not= 2 (quot status 100)) (ex-info "Invalid sticker"))]
+    (maybe-log-error log-error? :create-guild-sticker status (:body response))
     (when-not (= status 429)
       (if (some? body)
         (a/>!! prom body)


### PR DESCRIPTION
This PR adds a mechanism that logs status code and response body of unsuccessful requests. The current "silent" behaviour of discljord, i.e. if trace logging is not enabled, can sometimes make it rather difficult to find out
1. if a request is failing
2. which request is failing
3. why the request is failing

unless you check the response of each request manually, which is not always the case.

This "logging by default" functionality aims to improve that and gives you a helpful indicator that something is wrong. To complement this addition, there is a new parameter for every endpoint called `:log-error?` which determines whether this new logging behaviour should be enabled. By default, it is `true`, but it can be set to `false` for any request if desired.

The PR also introduces a small fix: The generated `:keys` clause in the parameters of endpoint functions generated by `defendpoint` was using keywords, when, according to the syntax, it should be symbols. I.e. `:keys [:a :b :c]` instead of the correct `:keys [a b c]`. This does not seem to have any effect on anything at the moment, but it has been fixed regardless. I've also generally removed some redundancies from the `defendpoint` macro.