### PR TITLE
Fix incorrect parsing behaviour in `parse-if-str`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Fixed
+- Fix incorrect parsing behaviour by `parse-if-str` for leading 0s
 - Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`
 - Fix typo in `modify-guild-role!` endpoint name (`modifiy` -> `modify`)
 - Fix typo in `start-thread-without-message!` which prevented it from working

--- a/src/discljord/util.clj
+++ b/src/discljord/util.clj
@@ -85,7 +85,7 @@
 (defn parse-if-str [input]
   (cond
     (number? input) input
-    (string? input) (let [parsed (edn/read-string input)]
+    (string? input) (let [parsed (Long/parseLong input)]
                       (if (number? parsed)
                         parsed
                         (throw (IllegalArgumentException. "String must represent a valid number"))))


### PR DESCRIPTION
Fixes #111 .
`edn/read-string` interprets numbers with leading 0s as octal representations, which we don't want. It has been replaced by `Long/parseLong`. This also means it can no longer read floating point numbers or numbers larger than the long capacity, but that was never really intended, as this function's purpose is mainly parsing numbers for bitwise manipulation (that fit in the long capacity) and parsing discriminators, which are always integers < 10000.