### PR TITLE
Implement guild scheduled events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+- Endpoints for guild scheduled events
+- New `cdn` functions for generating base64-encoded data uri images
 - Every endpoint function can now log error responses at log level ERROR. This is enabled by default, but can be disabled for individual invocations using the new keyword arg `:log-error?` that is available for every endpoint function.
 
 ### Fixed
+- `with-counts?` parameter in `get-invite!` -> `with-counts`
 - Fix incorrect parsing behaviour by `parse-if-str` for leading 0s
 - Keyword args in endpoint functions were declared incorrectly (`:keys [:a :b :c]` instead of `:keys [a b c]`). This had no semantic effect but has been corrected nonetheless.
 - Fix missing implementation for `add-channel-pinned-message!`, delegate to new endpoints `pin-`/`unpin-message`

--- a/src/discljord/cdn.clj
+++ b/src/discljord/cdn.clj
@@ -108,7 +108,12 @@
     (gif? bytes) "gif"
     :else nil))
 
-(defn data-uri-image [input]
+(defn data-uri-image
+  "Takes an input image and encodes it as a data uri.
+
+  The `input` may be anything that is accepted by `clojure.java.io/input-stream`.
+  This function returns `nil` if the content type of the input is not supported."
+  [input]
   (let [out (ByteArrayOutputStream.)
         _ (io/copy (io/input-stream input) out)
         bytes (.toByteArray out)

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -603,8 +603,8 @@
 
 (defendpoint create-guild-scheduled-event! ::ds/guild-id
   "Creates a guild scheduled event, returns the resulting event object in a promise on success."
-  [name privacy-level scheduled-start-time entity-type]
-  [channel-id entity-metadata scheduled-end-time description image])
+  [ms.event/name privacy-level scheduled-start-time entity-type]
+  [channel-id entity-metadata scheduled-end-time ms.event/description ms.event/image])
 
 (defendpoint get-guild-scheduled-event! ::ds/guild-id
   "Returns a promise containing the scheduled event with the given id for the given guild."
@@ -614,7 +614,8 @@
 (defendpoint modify-guild-scheduled-event! ::ds/guild-id
   "Modifies the given parameters of the scheduled event with the given id for the given guild."
   [event-id]
-  [channel-id entity-metadata name privacy-level scheduled-start-time scheduled-end-time description entity-type status image])
+  [channel-id entity-metadata ms.event/name privacy-level scheduled-start-time scheduled-end-time
+   ms.event/description entity-type ms.event/status ms.event/image])
 
 (defendpoint delete-guild-scheduled-event! ::ds/guild-id
   "Deletes scheduled event with the given id, returning a promise of whether it succeeded."

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -594,6 +594,39 @@
   [style])
 
 ;; --------------------------------------------------
+;; Scheduled Events
+
+(defendpoint list-guild-scheduled-events! ::ds/guild-id
+  "Returns a promise containing a list of scheduled events for the given guild"
+  []
+  [with-user-count?])
+
+(defendpoint create-guild-scheduled-event! ::ds/guild-id
+  "Creates a guild scheduled event, returns the resulting event object in a promise on success."
+  [name privacy-level scheduled-start-time entity-type]
+  [channel-id entity-metadata scheduled-end-time description image])
+
+(defendpoint get-guild-scheduled-event! ::ds/guild-id
+  "Returns a promise containing the scheduled event with the given id for the given guild."
+  [event-id]
+  [with-user-count?])
+
+(defendpoint modify-guild-scheduled-event! ::ds/guild-id
+  "Modifies the given parameters of the scheduled event with the given id for the given guild."
+  [event-id]
+  [channel-id entity-metadata name privacy-level scheduled-start-time scheduled-end-time description entity-type status image])
+
+(defendpoint delete-guild-scheduled-event! ::ds/guild-id
+  "Deletes scheduled event with the given id, returning a promise of whether it succeeded."
+  [event-id]
+  [])
+
+(defendpoint get-guild-scheduled-event-users! ::ds/guild-id
+  "Returns a promise containing a list of event users subscribed to the given event."
+  [event-id]
+  [limit with-member? before after])
+
+;; --------------------------------------------------
 ;; Invite
 
 (defendpoint get-invite! nil

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -599,7 +599,7 @@
 (defendpoint list-guild-scheduled-events! ::ds/guild-id
   "Returns a promise containing a list of scheduled events for the given guild"
   []
-  [with-user-count?])
+  [with-user-count])
 
 (defendpoint create-guild-scheduled-event! ::ds/guild-id
   "Creates a guild scheduled event, returns the resulting event object in a promise on success."
@@ -609,7 +609,7 @@
 (defendpoint get-guild-scheduled-event! ::ds/guild-id
   "Returns a promise containing the scheduled event with the given id for the given guild."
   [event-id]
-  [with-user-count?])
+  [with-user-count])
 
 (defendpoint modify-guild-scheduled-event! ::ds/guild-id
   "Modifies the given parameters of the scheduled event with the given id for the given guild."
@@ -624,7 +624,7 @@
 (defendpoint get-guild-scheduled-event-users! ::ds/guild-id
   "Returns a promise containing a list of event users subscribed to the given event."
   [event-id]
-  [limit with-member? before after])
+  [limit with-member before after])
 
 ;; --------------------------------------------------
 ;; Invite
@@ -632,7 +632,7 @@
 (defendpoint get-invite! nil
   "Returns a promise containing the invite."
   [invite-code]
-  [with-counts?])
+  [with-counts])
 
 (defendpoint delete-invite! nil
   "Deletes the invite. Returns a promise containing the deleted invite."

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -115,7 +115,7 @@
     `(defdispatch ~name
        ~params [] ~opts ~method ~status ~body
        ~url
-       ~(if delete? `{} `{:body (json/write-str ~opts)})
+       ~(if delete? `{} `{:body (json/write-str (conform-to-json ~opts))})
        ~(if delete? `(= ~status 204) `(json-body ~body)))))
 
 (defdispatch :get-guild-audit-log
@@ -671,6 +671,46 @@
   (str "/guilds/" guild-id "/widget.png")
   {:query-params (:style opts)
    :body (json/write-str (dissoc opts :style))}
+  (json-body body))
+
+(defdispatch :list-guild-scheduled-events
+  [guild-id] [] opts :get _ body
+  (str "/guilds/" guild-id "/scheduled-events")
+  {:query-params (conform-to-json opts)}
+  (json-body body))
+
+(defdispatch :create-guild-scheduled-event
+  [guild-id name privacy-level scheduled-start-time entity-type [] opts :post _ body]
+  (str "/guilds/" guild-id "/scheduled-events")
+  {:body (-> opts
+             (assoc :guild-id guild-id :name name
+                    :privacy-level privacy-level
+                    :scheduled-start-time scheduled-start-time
+                    :entity-type entity-type)
+             conform-to-json
+             json/write-str)}
+  (json-body body))
+
+(defdispatch :get-guild-scheduled-event
+  [guild-id event-id] [] opts :get _ body
+  (str "/guilds/" guild-id "/scheduled-events/" event-id)
+  {:query-params (conform-to-json opts)}
+  (json-body body))
+
+(def-message-dispatch :modify-guild-scheduled-event
+  [guild-id event-id]
+  :patch
+  (str "/guilds/" guild-id "/scheduled-events/" event-id))
+
+(def-message-dispatch :delete-guild-scheduled-event
+  [guild-id event-id]
+  :delete
+  (str "/guilds/" guild-id "/scheduled-events/" event-id))
+
+(defdispatch :get-guild-scheduled-event-users
+  [guild-id event-id] [] opts :get _ body
+  (str "/guilds/" guild-id "/scheduled-events/" event-id)
+  {:query-params (conform-to-json opts)}
   (json-body body))
 
 (defdispatch :get-invite

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -709,7 +709,7 @@
 
 (defdispatch :get-guild-scheduled-event-users
   [guild-id event-id] [] opts :get _ body
-  (str "/guilds/" guild-id "/scheduled-events/" event-id)
+  (str "/guilds/" guild-id "/scheduled-events/" event-id "/users")
   {:query-params (conform-to-json opts)}
   (json-body body))
 

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -680,7 +680,7 @@
   (json-body body))
 
 (defdispatch :create-guild-scheduled-event
-  [guild-id name privacy-level scheduled-start-time entity-type [] opts :post _ body]
+  [guild-id name privacy-level scheduled-start-time entity-type] [] opts :post _ body
   (str "/guilds/" guild-id "/scheduled-events")
   {:body (-> opts
              (assoc :guild-id guild-id :name name

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -456,3 +456,37 @@
 (s/def :discljord.messaging.specs.sticker/name (string-spec 2 30))
 (s/def :discljord.messaging.specs.sticker/description (string-spec 2 100))
 (s/def :discljord.messaging.specs.sticker/tags (string-spec 2 200))
+
+
+(s/def ::event-id ::ds/snowflake)
+(s/def ::with-user-count boolean?)
+
+(s/def :discljord.messaging.specs.event/name (string-spec 1 100))
+(s/def :discljord.messaging.specs.event/description (string-spec 1 1000))
+(s/def :discljord.messaging.specs.event/image (string-spec #"data:image/(jpeg|png|gif);base64,.+"))
+
+(def event-privacy-levels
+  {:guild-only 2})
+
+(s/def ::privacy-level (set (vals event-privacy-levels)))
+
+(s/def ::scheduled-start-time string?)
+(s/def ::scheduled-end-time string?)
+
+(def event-entity-types
+  {:stage-instance 1
+   :voice 2
+   :external 3})
+
+(s/def ::entity-type (set (vals event-entity-types)))
+(s/def :discljord.messaging.specs.event.metadata/location (string-spec 1 100))
+(s/def ::entity-metadata (s/keys :opt-un [:discljord.messaging.specs.event.metadata/location]))
+
+(def event-statuses
+  {:scheduled 1
+   :active 2
+   :completed 3
+   :canceled 4})
+
+(s/def :discljord.messaging.specs.event/status (set (vals event-statuses)))
+(s/def ::with-member boolean?)


### PR DESCRIPTION
Scheduled events have been out for a while and this PR implements all missing endpoints in that area. It also adds a few more convenience functions to the cdn namespace that aim to help with the creation of cover images for events.