### PR TITLE
Command changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@ Discljord follows semantic versioning.
 
 ## [Unreleased]
 ### Added
+- New application command parameters in various endpoints regarding: localization, default-member-permission, dm-permission
 - Endpoints for guild scheduled events
 - New `cdn` functions for generating base64-encoded data uri images
 - Every endpoint function can now log error responses at log level ERROR. This is enabled by default, but can be disabled for individual invocations using the new keyword arg `:log-error?` that is available for every endpoint function.
 
+### Changed
+- Deprecated `batch-edit-application-command-permissions!` because it doesn't work anymore
+
 ### Fixed
+- `edit-{global|guild}-application-command!` endpoints incorrectly expecting name and description as mandatory arguments
 - `with-counts?` parameter in `get-invite!` -> `with-counts`
 - Fix incorrect parsing behaviour by `parse-if-str` for leading 0s
 - Keyword args in endpoint functions were declared incorrectly (`:keys [:a :b :c]` instead of `:keys [a b c]`). This had no semantic effect but has been corrected nonetheless.

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -871,17 +871,18 @@
   [])
 
 (defendpoint edit-application-command-permissions! nil
-  "Sets the permission settings for the given command in the guild.
+  "NOT INTENDED FOR BOT USE. Sets the permission settings for the given command in the guild.
 
   Returns a promise containing the updated permission settings in a map with some additional information."
   [application-id guild-id command-id ms.command/permissions]
   [])
 
 (defendpoint ^:deprecated batch-edit-application-command-permissions! nil
-  "Batch edits the permission settings for all commands in a guild.
+  "Deprecated - This endpoint does not work anymore.
 
-  This will overwrite all existing permissions for all commands in the guild.
-  Returns a promise containing the updated permission settings."
+  The successor to its functionality is the `default-member-permission` parameter that can be set for commands.
+  More fine-grained permission settings are up to users now -
+  they can configure command permissions in their Discord server settings."
   [application-id guild-id ms.command.guild/permissions-array]
   [])
 

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -792,14 +792,19 @@
   New global commands will be available in all guilds after 1 hour.
   Returns a promise containing the new application command object."
   [application-id ms.command/name ms.command/description]
-  [ms.command/options ms.command/default-permission ms.command/type])
+  [ms.command/name-localizations ms.command/description-localizations
+   ms.command/options ms.command/default-member-permissions ms.command/dm-permission
+   ms.command/default-permission ms.command/type])
 
 (defendpoint edit-global-application-command! nil
   "Updates an existing global slash command by its id.
 
   Returns a promise containing the updated application command object."
   [application-id command-id]
-  [ms.command/name ms.command/description ms.command/options ms.command/default-permission ms.command/type])
+  [ms.command/name ms.command/description
+   ms.command/name-localizations ms.command/description-localizations
+   ms.command/options ms.command/default-member-permissions ms.command/dm-permission
+   ms.command/default-permission ms.command/type])
 
 (defendpoint delete-global-application-command! nil
   "Deletes an existing global slash command by its id.
@@ -826,14 +831,19 @@
 
   Returns a promise containing the new application command object."
   [application-id guild-id ms.command/name ms.command/description]
-  [ms.command/options ms.command/default-permission ms.command/type])
+  [ms.command/name-localizations ms.command/description-localizations
+   ms.command/options ms.command/default-member-permissions
+   ms.command/default-permission ms.command/type])
 
 (defendpoint edit-guild-application-command! nil
   "Updates an existing guild slash command by its id.
 
   Returns a promise containing the updated application command object."
   [application-id guild-id command-id]
-  [ms.command/name ms.command/description ms.command/options ms.command/default-permission ms.command/type])
+  [ms.command/name ms.command/description
+   ms.command/name-localizations ms.command/description-localizations
+   ms.command/options ms.command/default-member-permissions
+   ms.command/default-permission ms.command/type])
 
 (defendpoint delete-guild-application-command! nil
   "Deletes an existing guild slash command by its id.

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -784,7 +784,7 @@
 (defendpoint get-global-application-commands! nil
   "Returns a promise containing a vector of application command objects."
   [application-id]
-  [])
+  [with-localizations])
 
 (defendpoint create-global-application-command! nil
   "Creates or updates a global slash command.
@@ -824,7 +824,7 @@
 (defendpoint get-guild-application-commands! nil
   "Returns a promise containing a vector of application command objects."
   [application-id guild-id]
-  [])
+  [with-localizations])
 
 (defendpoint create-guild-application-command! nil
   "Creates or updates a guild slash command.

--- a/src/discljord/messaging.clj
+++ b/src/discljord/messaging.clj
@@ -877,7 +877,7 @@
   [application-id guild-id command-id ms.command/permissions]
   [])
 
-(defendpoint batch-edit-application-command-permissions! nil
+(defendpoint ^:deprecated batch-edit-application-command-permissions! nil
   "Batch edits the permission settings for all commands in a guild.
 
   This will overwrite all existing permissions for all commands in the guild.

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -872,12 +872,8 @@
   [webhook-id webhook-token message-id] :delete
   (webhook-url webhook-id webhook-token message-id))
 
-(defn- command-params [name description options default-perm type]
-  {:body (json/write-str (cond-> {:name name
-                                  :description description}
-                                 options (assoc :options options)
-                                 (some? default-perm) (assoc :default_permission default-perm)
-                                 type (assoc :type type)))})
+(defn- command-params [opts]
+  {:body (json/write-str (conform-to-json opts))})
 
 (defn- global-cmd-url
   ([application-id] (str "/applications/" application-id "/commands"))
@@ -892,16 +888,16 @@
 
 
 (defdispatch :create-global-application-command
-  [_ application-id name description] [options default-permission type] _ :post status body
+  [_ application-id name description] [] opts :post status body
   (global-cmd-url application-id)
-  (command-params name description options default-permission type)
+  (command-params (assoc opts :name name :description description))
   (cond->> (json-body body)
     (not= 2 (quot status 100)) (ex-info "Attempted to create an invalid global command")))
 
 (defdispatch :edit-global-application-command
-  [_ application-id command-id name description] [options default-permission type] _ :patch status body
+  [_ application-id command-id] [] opts :patch status body
   (global-cmd-url application-id command-id)
-  (command-params name description options default-permission type)
+  (command-params opts)
   (cond->> (json-body body)
     (not= 2 (quot status 100)) (ex-info "Attempted to edit an invalid global command")))
 
@@ -929,17 +925,17 @@
   (json-body body))
 
 (defdispatch :create-guild-application-command
-  [_ application-id guild-id name description] [options default-permission type] _ :post status body
+  [_ application-id guild-id name description] [] opts :post status body
   (guild-cmd-url application-id guild-id)
-  (command-params name description options default-permission type)
+  (command-params (assoc opts :name name :description description))
   (cond->> (json-body body)
     (not= 2 (quot status 100)) (ex-info "Attempted to create an invalid guild command")))
 
 (defdispatch :edit-guild-application-command
-  [_ application-id guild-id command-id name description] [options default-permission type] _ :patch status body
+  [_ application-id guild-id command-id] [] opts :patch status body
   (guild-cmd-url application-id guild-id command-id)
-  (command-params name description options default-permission type)
-  (cond->> (json-body body)
+  (command-params opts)
+  (->> (json-body body)
     (not= 2 (quot status 100)) (ex-info "Attempted to edit an invalid guild command")))
 
 (defdispatch :delete-guild-application-command

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -934,7 +934,7 @@
   [_ application-id guild-id command-id] [] opts :patch status body
   (guild-cmd-url application-id guild-id command-id)
   (command-params opts)
-  (->> (json-body body)
+  (cond->> (json-body body)
     (not= 2 (quot status 100)) (ex-info "Attempted to edit an invalid guild command")))
 
 (defdispatch :delete-guild-application-command

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -881,11 +881,10 @@
 
 
 (defdispatch :get-global-application-commands
-  [_ application-id] [] _ :get _ body
+  [_ application-id] [] opts :get _ body
   (global-cmd-url application-id)
-  {}
+  {:query-params (conform-to-json opts)}
   (json-body body))
-
 
 (defdispatch :create-global-application-command
   [_ application-id name description] [] opts :post status body
@@ -919,9 +918,9 @@
   ([application-id guild-id command-id] (str (guild-cmd-url application-id guild-id) \/ command-id)))
 
 (defdispatch :get-guild-application-commands
-  [_ application-id guild-id] [] _ :get _ body
+  [_ application-id guild-id] [] opts :get _ body
   (guild-cmd-url application-id guild-id)
-  {}
+  {:query-params (conform-to-json opts)}
   (json-body body))
 
 (defdispatch :create-guild-application-command

--- a/src/discljord/messaging/specs.clj
+++ b/src/discljord/messaging/specs.clj
@@ -379,6 +379,9 @@
              (or (<= amount 1)
                  (and (= amount 2) first-required?))))))
 
+(s/def :permission/bit-set-string (s/and string? (fn [str] (every? #(Character/isDigit %) str))))
+(s/def :discljord.messaging.specs.command/default-member-permission :permission/bit-set-string)
+(s/def :discljord.messaging.specs.command/dm-permission boolean?)
 (s/def :discljord.messaging.specs.command/default-permission boolean?)
 
 (s/def :command.option/options :discljord.messaging.specs.command/options)
@@ -386,6 +389,11 @@
 (s/def :discljord.messaging.specs.command/name (string-spec #"\S{1,32}"))
 
 (s/def :discljord.messaging.specs.command/description (string-spec 1 100))
+
+(s/def :discljord.messaging.specs.command/name-localizations (s/and map? #(every? (partial s/valid? :discljord.messaging.specs.command/name) (vals %))))
+(s/def :discljord.messaging.specs.command/description-localizations (s/and map? #(every? (partial s/valid? :discljord.messaging.specs.command/description) (vals %))))
+
+(s/def ::with-localizations boolean?)
 
 (def command-types
   {:chat-input 1
@@ -399,6 +407,10 @@
                           :discljord.messaging.specs.command/description]
                  :opt-un [:discljord.messaging.specs.command/options
                           :discljord.messaging.specs.command/default-permission
+                          :discljord.messaging.specs.command/dm-permission
+                          :discljord.messaging.specs.command/default-member-permission
+                          :discljord.messaging.specs.command/name-localizations
+                          :discljord.messaging.specs.command/description-localizations
                           :discljord.messaging.specs.command/type])
          (fn [cmd]
            (<= (->> cmd


### PR DESCRIPTION
This PR adds a couple new parameters to the application command endpoints, generally improves the way parameters are handled on the implementation side and fixes a bug in the `edit-...-command` endpoints that incorrectly treated name and description as required parameters. It also deprecates `batch-edit-application-command-permissions!` because this endpoint does not work anymore as command permissions work differently now.

Similarly, and this is somewhat of an open question, we could deprecate `edit-application-command-permissions!` because it [doesn't work with bots anymore](https://discord.com/developers/docs/interactions/application-commands#edit-application-command-permissions). I haven't done that so far though because we also have a couple other endpoints that require a Bearer token which are not deprecated. I have adjusted the documentation though.