### PR TITLE
Tweak maybe-log-error logic

### DIFF
--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -42,7 +42,7 @@
         user-agent)})
 
 (defn maybe-log-error [log-error? endpoint status response-body]
-  (when (and log-error? (not= (mod status 100) 2))
+  (when (and log-error? (not (<= 200 status 299)) (not= status 304))
     (log/error "Encountered error response" status "on" endpoint ":\n" response-body)))
 
 (defmacro defdispatch

--- a/src/discljord/messaging/impl.clj
+++ b/src/discljord/messaging/impl.clj
@@ -42,7 +42,7 @@
         user-agent)})
 
 (defn maybe-log-error [log-error? endpoint status response-body]
-  (when (and log-error? (not (<= 200 status 299)) (not= status 304))
+  (when (and log-error? (not= (quot status 100) 2) (not= status 304))
     (log/error "Encountered error response" status "on" endpoint ":\n" response-body)))
 
 (defmacro defdispatch


### PR DESCRIPTION
Currently `maybe-log-error` is logging all `2xx` responses as errors, and would ignore a `502` response.