### PR TITLE
bump core.async version to address warnings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        org.clojure/core.async {:mvn/version "1.3.618"}
+        org.clojure/core.async {:mvn/version "1.3.622"}
         org.clojure/data.json {:mvn/version "2.3.1"}
         org.clojure/tools.logging {:mvn/version "1.1.0"}
         http-kit/http-kit {:mvn/version "2.5.3"}


### PR DESCRIPTION
I was seeing the same warnings Sean reported [in Clojurians](https://clojurians-log.clojureverse.org/clojure-dev/2021-09-14/1631652327.035200) in my bot.

Partial output of `clj -X:deps tree` in my bot dir shows that the `core.async` version `discljord` depends on is older than the one that introduces the update to `tools.analyzer.jvm`:
```
com.github.discljord/discljord 1.3.1
  . org.clojure/core.async 1.3.618
    . org.clojure/tools.analyzer.jvm 1.1.0
      . org.clojure/tools.analyzer 1.0.0
```

1.3.622 is the `core.async` version they mention in that thread that directly cleans up these warnings. I opted for that instead of the latest (1.6.673).