### PR TITLE
Upgrade dependencies

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,11 +16,11 @@ jobs:
   codox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Clojure
         run: curl https://download.clojure.org/install/linux-install-1.11.1.1347.sh -o install-clj.sh && chmod +x install-clj.sh && sudo ./install-clj.sh
       - name: Cache clojure deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository
@@ -32,7 +32,7 @@ jobs:
         run: clojure -X:codox
         working-directory: ${{ github.workspace }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: target/doc
 
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/deps.edn
+++ b/deps.edn
@@ -1,34 +1,32 @@
 {:paths ["src"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        org.clojure/core.async {:mvn/version "1.6.681"}
-        org.clojure/data.json {:mvn/version "2.4.0"}
-        org.clojure/tools.logging {:mvn/version "1.2.4"}
-        http-kit/http-kit {:mvn/version "2.7.0"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.1"}
+        org.clojure/core.async {:mvn/version "1.8.741"}
+        org.clojure/data.json {:mvn/version "2.5.1"}
+        org.clojure/tools.logging {:mvn/version "1.5.18"}
+        http-kit/http-kit {:mvn/version "2.8.0"}
         stylefruits/gniazdo {:mvn/version "1.2.2"}}
 
  :aliases
  {:dev {:extra-paths ["dev"]
-        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.4.11"}}
+        :extra-deps {ch.qos.logback/logback-classic {:mvn/version "1.5.18"}}
         :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}
   :test {:extra-paths ["test"]
          :extra-deps {http-kit.fake/http-kit.fake {:mvn/version "0.2.2"}
                       org.clojure/test.check {:mvn/version "1.1.1"}}}
-  :runner
-  {:extra-deps {com.cognitect/test-runner
-                {:git/url "https://github.com/cognitect-labs/test-runner"
-                 :sha "7284cda41fb9edc0f3bc6b6185cfb7138fc8a023"}}
-   :main-opts ["-m" "cognitect.test-runner"
-               "-d" "test"]}
-
+  :runner {:extra-paths ["test"]
+           :extra-deps {io.github.cognitect-labs/test-runner
+                        {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+           :main-opts ["-m" "cognitect.test-runner"]
+           :exec-fn cognitect.test-runner.api/test}
   :jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.303"}}
         :exec-fn hf.depstar/jar
         :exec-args {:jar "discljord.jar" :sync-pom true
                     :group-id "com.github.discljord" :artifact-id "discljord"
                     :version "1.3.1"}}
-  :install {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+  :install {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}
             :exec-fn deps-deploy.deps-deploy/deploy
             :exec-args {:installer :local :artifact "discljord.jar"}}
-  :deploy {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.1"}}
+  :deploy {:replace-deps {slipset/deps-deploy {:mvn/version "0.2.2"}}
            :exec-fn deps-deploy.deps-deploy/deploy
            :exec-args {:installer :remote :artifact "discljord.jar"
                        :sign-releases? true}}
@@ -37,4 +35,4 @@
           :exec-args {:source-paths ["src"]}}
   :outdated {;; Note that it is `:deps`, not `:extra-deps`
              :deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
-             :main-opts ["-m" "antq.core"]}}}
+             :main-opts ["-m" "antq.core" "--skip=pom"]}}}

--- a/project.clj
+++ b/project.clj
@@ -3,17 +3,17 @@
   :url "https://github.com/IGJoshua/discljord"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.11.1"]
-                 [org.clojure/core.async "1.5.648"]
-                 [org.clojure/data.json "2.4.0"]
-                 [org.clojure/tools.logging "1.2.4"]
-                 [http-kit/http-kit "2.6.0"]
-                 [stylefruits/gniazdo "1.2.1"]]
+  :dependencies [[org.clojure/clojure "1.12.1"]
+                 [org.clojure/core.async "1.8.741"]
+                 [org.clojure/data.json "2.5.1"]
+                 [org.clojure/tools.logging "1.3.0"]
+                 [http-kit/http-kit "2.8.0"]
+                 [stylefruits/gniazdo "1.2.2"]]
   :target-path "target/%s"
   :jar-name "discljord-%s.jar"
   :deploy-branches ["master" "release" "hotfix"]
   :profiles {:dev {:dependencies [[http-kit.fake/http-kit.fake "0.2.2"]
-                                  [ch.qos.logback/logback-classic "1.4.1"]]
+                                  [ch.qos.logback/logback-classic "1.5.18"]]
                    :plugins [[lein-codox "0.10.8"]]
                    :exclusions [http-kit]
                    :jvm-opts ["--add-opens" "java.base/java.lang=ALL-UNNAMED" "-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}})


### PR DESCRIPTION
This PR upgrades all stale dependencies, as identified by `clj -M:outdated`.

It also incidentally disables checking of `pom.xml` by that task, since in this project the `pom.xml` file is a derived asset and therefore should not be checked (it will be updated automatically when other build tasks are executed).